### PR TITLE
Update to spdlog 1.11.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,8 @@
 # Use `binary` to make sure certain files are never auto-detected as text.
 #
 #*.png binary
+
+spdlog-bench/spdlog-bench/bench_src symlink=dir
+spdlog-tests/spdlog-tests/tests_src symlink=dir
+spdlog/spdlog/include symlink=dir
+spdlog/spdlog/src symlink=dir

--- a/spdlog-bench/manifest
+++ b/spdlog-bench/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog-bench
-version: 1.10.0+3
+version: 1.11.0
 project: spdlog
 summary: Benchmarks package for spdlog
 topics: logging, C++

--- a/spdlog-tests/manifest
+++ b/spdlog-tests/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog-tests
-version: 1.10.0+3
+version: 1.11.0
 project: spdlog
 summary: Tests package for spdlog
 topics: logging, C++

--- a/spdlog/manifest
+++ b/spdlog/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog
-version: 1.10.0+3
+version: 1.11.0
 project: spdlog
 summary: Fast C++ logging library.
 license: MIT ; MIT License
@@ -20,6 +20,6 @@ requires: c++ >= 11
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
 
-depends: fmt ^8.1.1
+depends: fmt ^9.1.0
 
 build-exclude: linux_debian_10-emcc_2.0.25   ; Compiler error, use at your own risks.


### PR DESCRIPTION
### Update to spdlog 1.11.0
1. Update upstream to new release here https://github.com/gabime/spdlog/releases/tag/v1.11.0.
2. Also add forgotten symlink to `.gitattributes`.