### PR TITLE
Update to spdlog 1.12.0

### DIFF
--- a/spdlog-bench/manifest
+++ b/spdlog-bench/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog-bench
-version: 1.11.0+1
+version: 1.12.0-a.0.z
 project: spdlog
 summary: Benchmarks package for spdlog
 topics: logging, C++

--- a/spdlog-tests/manifest
+++ b/spdlog-tests/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog-tests
-version: 1.11.0+1
+version: 1.12.0-a.0.z
 project: spdlog
 summary: Tests package for spdlog
 topics: logging, C++

--- a/spdlog-tests/manifest
+++ b/spdlog-tests/manifest
@@ -13,3 +13,4 @@ email: gmelman1@gmail.com
 package-email: wmbat-dev@protonmail.com
 depends: * build2 >= 0.14.0
 depends: * bpkg >= 0.14.0
+depends: catch2 ^3.3.2

--- a/spdlog-tests/spdlog-tests/buildfile
+++ b/spdlog-tests/spdlog-tests/buildfile
@@ -1,4 +1,4 @@
-import libs = spdlog%lib{spdlog}
+import libs = spdlog%lib{spdlog} catch2%liba{catch2wmain}
 
 exe{driver}: tests_src/{cxx hxx}{** -test_systemd -test_misc} tests_src/hxx{*.hpp} $libs testscript{**}
 

--- a/spdlog/manifest
+++ b/spdlog/manifest
@@ -1,6 +1,6 @@
 : 1
 name: spdlog
-version: 1.11.0+1
+version: 1.12.0-a.0.z
 project: spdlog
 summary: Fast C++ logging library.
 license: MIT ; MIT License

--- a/spdlog/manifest
+++ b/spdlog/manifest
@@ -20,6 +20,6 @@ requires: c++ >= 11
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
 
-depends: fmt ^9.1.0
+depends: fmt ^10.1.1
 
 build-exclude: linux_debian_10-emcc_2.0.25   ; Compiler error, use at your own risks.


### PR DESCRIPTION
* Changes package versions to `1.12.0-a.0.z`.
* Updates `upstream/` to `v1.12.0`.
* Updates `fmt` to `^10.1.1`.