### PR TITLE
Fix incorrect linking of `advapi32`

### DIFF
--- a/spdlog/spdlog/buildfile
+++ b/spdlog/spdlog/buildfile
@@ -35,8 +35,8 @@ if($cxx.target.class == 'windows')
 {
   if($cxx.id == 'gcc')
   {
-    cxx.libs += -LAdvapi32.lib
-    lib{spdlog}: cxx.export.libs += -LAdvapi32.lib
+    cxx.libs += -ladvapi32
+    lib{spdlog}: cxx.export.libs += -ladvapi32
   }
   else
   {


### PR DESCRIPTION
Fixes #19. This should be merged before #20, and a new revision of `1.11.0` be released.

See CI run here:
https://ci.stage.build2.org/@eaac60d5-d6bd-4050-abf7-1aa80fd162bb?builds=&pv=&th=*&tg=&tc=&pc=&rs=*